### PR TITLE
Object Type data parsing for the blade template

### DIFF
--- a/src/globals/functions.php
+++ b/src/globals/functions.php
@@ -20,8 +20,11 @@ if (!function_exists('view')) {
      *
      * @return string
      */
-    function view(string $view, array $data = [])
+    function view(string $view, array|object $data = [])
     {
+        if(is_object($data))
+			$data = (array) $data;
+        
         if (ViewConfig('render')) {
             if (ViewConfig('config')) {
                 call_user_func_array(ViewConfig('config'), [[
@@ -58,7 +61,7 @@ if (!function_exists('render')) {
      * @param string $view The view to render
      * @param array $data The data to pass to the view
      */
-    function render(string $view, array $data = [])
+    function render(string $view, array|object $data = [])
     {
         (new \Leaf\Http\Response())->markup(view($view, $data));
     }


### PR DESCRIPTION
Added object parsing support for the blade view function

## Description
Added object parsing support for the blade view function, the view and render functions are explicitly set to receive the $data parameter as of type array, which is also fine but it's not very presentable when have very little or very large amount of data.

So I modified the $data parameter in the `view` and `render` function to also receive objects,  if the then received data is object  it is converted to array.

## Comparison between array and object passing as data in the view function

```php
# passing data as array on the view

$data = [
    'title' => 'My Page Title',
    'foo' => 'My Foo Content',
    'bar' => 'My Bar Content'
];

render('page', $data);
```

```php
# passing data as of type object to the view
# assuming (object) $data in initialized in the BaseController

$this->data->title = 'My Page Title'
$this->data->foo = 'My Foo Content'
$this->data->bar = 'My Bar Content'

render('page' $this->data)
```

While this could be subjective from user to user, I think the data passed as an object look more presentable and are less congested.