### PR TITLE
Fix: Issue with RouteName Handling

### DIFF
--- a/src/globals/functions.php
+++ b/src/globals/functions.php
@@ -82,11 +82,30 @@ if (!function_exists('redirect')) {
 if (!function_exists('route')) {
     /**
      * Get a route by name
-     * @param string $route The route to get
+     * @param group ...$args The route to get
      */
-    function route(string $route)
+    function route()
     {
-        return app()->route($route);
+        $args = func_get_args();
+
+        $routeName = array_shift($args);
+        $routeParams = count($args) > 0 ? $args : [];
+
+        $route = app()->route($routeName);
+
+        # check if it has args to replace
+        if (preg_match_all('/\{([^}]+)\}/', $route, $matches)) {
+            foreach ($matches[1] as $key => $paramName) {
+                if (isset($routeParams[$key])) {
+                    $route = str_replace('{' . $paramName . '}', $routeParams[$key], $route);
+                } else {
+                    // Handle missing parameters
+                    throw new InvalidArgumentException("Missing parameter '$paramName' for route '$routeName'.");
+                }
+            }
+        }
+    
+        return $route;
     }
 }
 


### PR DESCRIPTION
## Issue with RouteName Handling

This PR fixes an issue with the `route()` of the global function where URL parameters were not being replaced in the route pattern. When using routes with placeholders, such as 

```php
app()->get('book/{id}', ['name'=>'book.show', function($id){
    echo route('book.show', $id);
}]);
```
The expected output should be `/book/2` when accessing `mydomain.com/book/2`. However, the response from route() was always the original route pattern `/book/{id}`, without the URL parameters being pre-passed.

## Related Issue

https://github.com/leafsphp/mvc-core/issues/11