### PR TITLE
add fix on seed method

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -313,7 +313,12 @@ class Schema
 
                             if (strpos($fakerMethod, ':') !== false) {
                                 $fakerMethod = explode(':', $fakerMethod);
-                                $localFakerInstance = $localFakerInstance->{$fakerMethod[0]}($fakerMethod[1]);
+                                if (strpos($fakerMethod[1], ',') !== false) {
+                                    $array_params = explode(",",$fakerMethod[1]);
+                                    $localFakerInstance = $localFakerInstance->{$fakerMethod[0]}($array_params);
+                                } else {
+                                    $localFakerInstance = $localFakerInstance->{$fakerMethod[0]}($fakerMethod[1]);
+                                }
                             } else {
                                 $localFakerInstance = $localFakerInstance->{$fakerMethod}();
                             }


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

I was trying to run this migration but I couldn't.
`    type: '@faker.randomElements:bank,cash'`

After drawing the application, he discovered that the error was in this line of code. The argument was sent to the function, but the case of that argument being a array was not considered, so it was passed as a string and subsequently failed to execute the Faker library.

`$localFakerInstance = $localFakerInstance->{$fakerMethod[0]}($fakerMethod[1]);`

The solution is to evaluate whether the condition is an array and format it so that the function actually runs in the generator.

```
                                if (strpos($fakerMethod[1], ',') !== false) {
                                    $arr = explode(",",$fakerMethod[1]);
                                    $localFakerInstance = $localFakerInstance->{$fakerMethod[0]}($arr);
```
If it is not an arrangement, the previous condition is executed and the regular flow of the application continues.

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [ ] Yes
- [X] No

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->

<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
