### PR TITLE
Escape quotes in ServeCommand for Windows compatibility

### DIFF
--- a/src/Commands/ServeCommand.php
+++ b/src/Commands/ServeCommand.php
@@ -210,7 +210,8 @@ class ServeCommand extends Command
         $phpCommand = $this->buildPhpServerCommand();
 
         if ($this->isWindows()) {
-            return "npx @leafphp/watcher --watch .env --exec " . escapeshellarg($phpCommand);
+            $phpCommand = str_replace('"', '\\"', $phpCommand);
+            return "\"npx @leafphp/watcher --watch .env --exec \\\"$phpCommand\\\"\"";
         }
 
         return escapeshellcmd("npx @leafphp/watcher --watch .env --exec \"$phpCommand\"");
@@ -222,7 +223,7 @@ class ServeCommand extends Command
     protected function buildNpmRunCommand($script)
     {
         if ($this->isWindows()) {
-            return "npm run $script";
+            return "\"npm run $script\"";
         }
 
         return "\"npm run $script\"";


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; how it makes building easier, etc.
	You can link to issues here.
-->

The command wasn't working as expected in Windows. This fix aims to correct that.

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [x] Yes
- [ ] No

OBS: This issue has already been discussed on Discord.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->

<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
